### PR TITLE
[runners] remove go get step

### DIFF
--- a/tool/runners/exceptions.py
+++ b/tool/runners/exceptions.py
@@ -4,7 +4,3 @@ class CompilationError(Exception):
 
 class RuntimeError(Exception):
     pass
-
-
-class DependenciesError(Exception):
-    pass

--- a/tool/runners/go.py
+++ b/tool/runners/go.py
@@ -5,21 +5,12 @@ from subprocess import check_output, Popen, PIPE
 import tempfile
 
 from tool.runners.wrapper import SubmissionWrapper
-from tool.runners.exceptions import CompilationError, RuntimeError, DependenciesError
+from tool.runners.exceptions import CompilationError, RuntimeError
 
 
 class SubmissionGo(SubmissionWrapper):
     def __init__(self, file):
         SubmissionWrapper.__init__(self)
-        relpath = os.path.join(".", file)
-        abspath = os.path.realpath(file)
-        gopath = os.path.realpath(
-            check_output(["go", "env", "GOPATH"]).decode().strip()
-        )
-        if not abspath.startswith(gopath):
-            dep_output = check_output(["go", "get", "-d", relpath]).decode()
-            if dep_output:
-                raise DependenciesError(dep_output)
         tmp = tempfile.NamedTemporaryFile(prefix="aoc")
         tmp.close()
         compile_output = check_output(["go", "build", "-o", tmp.name, file]).decode()


### PR DESCRIPTION
Nobody really knows why this `go get -d` is there
Probably to yolo install missing dependencies at runtime if they are missing ( likely useful in the CI )

Anyway it does not work with the latest versions of go
So let's remove it, and we can figure out the CI later

```bash
# Good old version of go
$ docker run -it --rm golang:1.13 /bin/bash
root@3aad08a56511:/go# touch trucmuche.go
root@3aad08a56511:/go# go get -d ./trucmuche.go
can't load package: package main:
trucmuche.go:1:1: expected 'package', found 'EOF'
```
```bash
# Broken new version of go
$ docker run -it --rm golang:1.15 /bin/bash
root@ff01109a0476:/go# touch trucmuche.go
root@ff01109a0476:/go# go get -d ./trucmuche.go
go get: ./trucmuche.go exists as a file, but 'go get' requires package arguments
```

More concretely, here is what happens on the [current head](https://github.com/david-ds/adventofcode-2020/tree/ad49624365de8330102bc3a9df701fbfec9ab890)

```text
$ go version
go version go1.15.3 darwin/amd64
$ pipenv run ./aoc run -d1 -p1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Running submissions for day 01:

* part 1:
go get: ./day-01/part-1/claussa.go exists as a file, but 'go get' requires package arguments
Traceback (most recent call last):
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/./aoc", line 6, in <module>
    AOC()
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/tool/AOC.py", line 42, in __init__
    getattr(self, args.command)(sys.argv[2:])
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/tool/AOC.py", line 99, in run
    run(
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/tool/run.py", line 42, in run
    submissions = discovery.get_submissions(
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/tool/discovery.py", line 139, in get_submissions
    submissions.append(Submission(problem, author, ext))
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/tool/model.py", line 53, in __init__
    load_submission_runnable(self.path(), language) if init_runnable else None
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/tool/runners/__init__.py", line 64, in load_submission_runnable
    return SubmissionGo(path)
  File "/Users/ayaz.badouraly/Github/adventofcode-2020/tool/runners/go.py", line 20, in __init__
    dep_output = check_output(["go", "get", "-d", relpath]).decode()
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['go', 'get', '-d', './day-01/part-1/claussa.go']' returned non-zero exit status 1.
```