### PR TITLE
[workflows] use marketplace action for vlang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,16 @@ jobs:
       - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: 1.4.2
-      - uses: nocturlab/setup-vlang-action@v1
-        with:
-          v-version: latest
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: 0.7.0
+      # TODO: switch back to nocturlab/setup-vlang-action@v1 once https://github.com/nocturlab/setup-vlang-action/issues/72 is fixed
+      - name: Install vlang
+        run: |
+          wget -P /tmp https://github.com/vlang/v/releases/latest/download/v_linux.zip
+          unzip -d /tmp /tmp/v_linux.zip
+          sudo /tmp/v/v symlink
+          # We can not remove /tmp/v/ as /usr/local/bin/v needs some files in there
 
       # Install missing dependencies
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,12 @@ jobs:
       - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: 1.4.2
+      - uses: nocturlab/setup-vlang-action@v1
+        with:
+          v-version: latest
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: 0.7.0
-      - name: Compile vlang
-        run: cd /tmp && git clone https://github.com/vlang/v && cd v && make && sudo ./v symlink
 
       # Install missing dependencies
 


### PR DESCRIPTION
We spend about 15s per build on this step compiling again and again the same thing
Let's use the pre-built releases instead

See details in https://github.com/nocturlab/setup-vlang-action
Turns out the setup action is broken due to a double breaking change, see https://github.com/nocturlab/setup-vlang-action/issues/72
Moving back to some good old bash