### PR TITLE
[runners] use c++17 standard

### DIFF
--- a/tool/runners/cpp.py
+++ b/tool/runners/cpp.py
@@ -17,7 +17,7 @@ class SubmissionCpp(SubmissionWrapper):
                 "-Wall",
                 "-Wno-sign-compare",
                 "-O3",
-                "-std=c++14",
+                "-std=c++17",
                 "-o",
                 tmp.name,
                 file,


### PR DESCRIPTION
For some reason `%` operations do not produce the same results with `c++14`, upgrading fixes this issue

example here -> https://github.com/david-ds/adventofcode-2020/pull/273