### PR TITLE
[tool] add time distribution feature

### DIFF
--- a/tool/AOC.py
+++ b/tool/AOC.py
@@ -94,6 +94,13 @@ aoc commands are:
             action="store_true",
             default=False,
         )
+        parser.add_argument(
+            "-t",
+            "--times",
+            help="prints time distrubtion of solutions",
+            action="store_true",
+            default=False,
+        )
 
         args = parser.parse_args(argv)
 
@@ -108,6 +115,7 @@ aoc commands are:
             args.all,
             args.restricted,
             args.expand,
+            args.times,
         )
 
     @staticmethod

--- a/tool/distribution.py
+++ b/tool/distribution.py
@@ -1,0 +1,33 @@
+
+HISTOGRAM_CHARS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
+HISTOGRAM_WIDTH = 6
+
+
+def get_time_distribution(durations):
+    if not durations:
+        return ''
+    _max, _min = max(durations), min(durations)
+    n = HISTOGRAM_WIDTH
+    step = (_max - _min) / float(n)
+    r = [0] * (n + 1)
+    for i in range(n + 1):
+        c = 0
+        for d in durations:
+            if _min + i * step <= d < _min + (i + 1) * step:
+                c += 1
+        r[i] = c / len(durations)
+    s = []
+    for x in r:
+        found = False
+        for i, c in enumerate(HISTOGRAM_CHARS[1:]):
+            if i / n < x <= (i + 1) / n:
+                s.append(c)
+                found = True
+                break
+        if not found:
+            s.append(HISTOGRAM_CHARS[0])
+    return "{} [{:.03f}-{:.03f}]ms".format(
+        "".join(s),
+        _min,
+        _max,
+    )

--- a/tool/model.py
+++ b/tool/model.py
@@ -90,6 +90,7 @@ class Result(object):
         self.input = input
         self.answer = answer
         self.duration = duration
+        self.all_durations = []
 
     def __repr__(self):
         return "Result{%s, %s, %s, %s}" % (


### PR DESCRIPTION
add option `-t` to print duration distribution

```
./aoc run -d 13 -t
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Running submissions for day 13:

* part 1:
---------------------------------------------------
Avg over all inputs
---------------------------------------------------
----------  --------  -----------  ---  -----------------------
ayoub          171       0.001 ms  go   ▅▂▂▁▁▁▂ [0.001-0.001]ms
djou          3269       0.008 ms  go   ▃▂▃▁▁▃▂ [0.005-0.012]ms
th-ch          207       0.009 ms  go   ▃▄▁▂▁▁▂ [0.005-0.017]ms
bebert        4782       0.012 ms  pyx  ▅▂▂▂▁▁▂ [0.010-0.017]ms
thore         2305       0.012 ms  py   ▆▂▁▁▁▁▂ [0.011-0.020]ms
youyoun        171       0.016 ms  py   ▅▂▁▂▁▁▂ [0.014-0.020]ms
david         4315       0.025 ms  py   ▇▁▁▁▁▁▂ [0.022-0.045]ms
badouralix    2406       0.028 ms  py   ▃▂▂▃▂▁▂ [0.025-0.032]ms
coco          2165       0.032 ms  py   ▂▁▃▂▃▂▂ [0.025-0.036]ms
----------  --------  -----------  ---  -----------------------

* part 2:
---------------------------------------------------
Avg over all inputs
---------------------------------------------------
----------  --------------------  -----------  ---  -----------------------
ayoub          539746751134958       0.002 ms  go   ▃▃▂▂▂▁▂ [0.002-0.002]ms
djou           672754131923874       0.016 ms  go   ▂▁▃▃▁▃▂ [0.011-0.020]ms
th-ch          530015546283687       0.019 ms  go   ▂▃▃▁▁▃▁ [0.012-0.028]ms
bebert        1118684865113056       0.033 ms  pyx  ▄▃▂▁▂▁▂ [0.022-0.063]ms
thore          552612234243498       0.055 ms  py   ▂▄▃▁▂▁▂ [0.049-0.064]ms
coco           534035653563227       0.146 ms  py   ▃▄▁▂▁▂▂ [0.095-0.247]ms
badouralix     225850756401039       0.158 ms  py   ▂▂▄▂▁▂▂ [0.045-0.291]ms
david          556100168221141       0.201 ms  py   ▃▄▁▂▁▂▂ [0.115-0.379]ms
youyoun        539746751134958       0.207 ms  py   ▄▂▂▂▂▂▂ [0.154-0.291]ms
----------  --------------------  -----------  ---  -----------------------
```
